### PR TITLE
Fixed scanner problem when registry support not available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.3</version>
+    <version>1.554.1</version>
   </parent>
 
   <artifactId>TestComplete</artifactId>

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder/config.jelly
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder/config.jelly
@@ -54,6 +54,9 @@
         <f:entry title="${%Executor}" field="executorType">
           <f:select />
         </f:entry>
+        <f:entry title="${%ExecutorPath}" field="executorPath">
+          <f:textbox />
+        </f:entry>
         <f:entry title="${%Version}" field="executorVersion">
           <f:select />
         </f:entry>

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder/config.properties
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder/config.properties
@@ -21,6 +21,7 @@ GenerateMHT = Generate MHT log file
 publishJUnitReports = Generate JUnit-style report
 TimeoutInSeconds = Timeout (seconds):
 Executor = Test runner:
+ExecutorPath = Executor Path:
 Version = Version:
 ActionOnWarningsTitle = Action on warnings:
 ActionOnErrorsTitle = Action on errors:


### PR DESCRIPTION
Added parameter ExecutorPath for setting a static path to the test ex…ecutor binary. This overrides the behaviour of the Windows Registry scanner and enables test running when you don't have Windows Registry support built into your Jenkins installation (for example, in a Fedora 21 rpm-based install).

Updated minimum Jenkins version, see bug: https://issues.jenkins-ci.org/browse/JENKINS-19031