### PR TITLE
Do not mark aborted builds as FAILED

### DIFF
--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
@@ -492,6 +492,9 @@ public class TcTestBuilder extends Builder implements Serializable {
                     build.setResult(Result.FAILURE);
                 }
             }
+        } catch (InterruptedException e) {
+            // The build has been aborted. Let Jenkins mark it as ABORTED
+            throw e;
         } catch (Exception e) {
             TcLog.error(listener, Messages.TcTestBuilder_ExceptionOccurred(),
                     e.getCause() == null ? e.toString() : e.getCause().toString());


### PR DESCRIPTION
Aborting a Jenkins build (from the UI) in the TestComplete step marks the build as FAILED. Is is an issue because we don't know who aborted it. Also a failed build should indicate build errors.

When Jenkins aborts a build is interrupts the corresponding thread. Let's make sure the interrupt is handled.