### PR TITLE
* Resolving XXE threat SECURITY-2741 / CVE-2023-24443

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
 
   <artifactId>TestComplete</artifactId>
   <name>TestComplete support plug-in</name>
-  <version>2.8.2</version>
+  <version>2.9-SNAPSHOT</version>
+
   <packaging>hpi</packaging>
   <url>https://github.com/jenkinsci/testcomplete-plugin/blob/master/docs/README.md</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <artifactId>TestComplete</artifactId>
   <name>TestComplete support plug-in</name>
-  <version>2.9-SNAPSHOT</version>
+  <version>2.8.2</version>
   <packaging>hpi</packaging>
   <url>https://github.com/jenkinsci/testcomplete-plugin/blob/master/docs/README.md</url>
 

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/parser/LogNodeUtils.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/parser/LogNodeUtils.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import javax.xml.XMLConstants;
 
 /**
  * @author Igor Filin
@@ -155,6 +156,30 @@ class LogNodeUtils {
         return null;
     }
 
+    static private final String DISALLOW_DOCTYPE_DECL = 
+        "http://apache.org/xml/features/disallow-doctype-decl";
+    
+    static private final String EXTERNAL_GENERAL_ENTITIES = 
+        "http://xml.org/sax/features/external-general-entities";
+
+    static private final String EXTERNAL_PARAMETER_ENTITIES = 
+        "http://xml.org/sax/features/external-parameter-entities";
+
+    static private final String LOAD_EXTERNAL_DTD = 
+        "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+    // This is added to prevent XXE attack on xml parser
+    static private void secureDocumentBuilderFactory(DocumentBuilderFactory factory) 
+        throws ParserConfigurationException {
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature(EXTERNAL_GENERAL_ENTITIES , false);
+        factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+        factory.setFeature(LOAD_EXTERNAL_DTD, false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+    }
+
+
     static public Node getRootDocumentNodeFromArchive(ZipFile archive, String name) {
         if (name == null) {
             return null;
@@ -169,6 +194,7 @@ class LogNodeUtils {
         try {
             logDataStream = archive.getInputStream(rootLogDataEntry);
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            secureDocumentBuilderFactory(factory);
             DocumentBuilder builder = factory.newDocumentBuilder();
 
             Document document = builder.parse(logDataStream);


### PR DESCRIPTION
XXE vulnerability in TestComplete support Plugin
SECURITY-2741 / CVE-2023-24443
Severity (CVSS): High
Affected plugin: TestComplete
Description:
TestComplete support Plugin 2.8.1 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.

This allows attackers able to control the zip archive input file for the 'TestComplete Test' build step to have Jenkins parse a crafted file that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery.

# Solution
the instructions here are followed https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j

Inline DTD is used by TC for scheme and datatype validation so DECLTYPE is permitted 


