### PR TITLE
Fix the build process in POM.XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
     <findbugs.failOnError>false</findbugs.failOnError>
     <hpi-plugin.version>2.6</hpi-plugin.version>
@@ -38,28 +38,35 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1159.v0b_396e1e07dd</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.6.1.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.5
-      </version>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.7</version>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>io.jenkins.tools.bom</groupId>
+              <artifactId>bom-2.138.x</artifactId>
+              <version>4</version>
+              <scope>import</scope>
+              <type>pom</type>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/testcomplete-plugin.git</connection>


### PR DESCRIPTION
# Description
* Applying BOM on the dependency management
* Upgrade to 2.138.4

# Motivation 
after bumping version of junit and credentials in PR https://github.com/jenkinsci/testcomplete-plugin/pull/7 and https://github.com/jenkinsci/testcomplete-plugin/pull/9 .. the building process now is broken due to enforcer upper bound dependencies of these new packages
https://github.com/jenkinsci/testcomplete-plugin/pull/7#issuecomment-1433388023


<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
