### PR TITLE
TC-105074: Fix Stored XSS 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,12 @@ If you have any questions or need assistance with setting up the plugin and conf
 
 ## *Version History*
 
+#### Version 2.9.2
+-   Fix Stored XSS vulnerability (SECURITY-2892 / CVE-2023-33002)
+
+#### Version 2.9.1
+-   Fix XXE vulnerability (SECURITY-2741 / CVE-2023-24443)
+
 #### Version 2.6.2
 -   Support for the TestExecute Lite utility has been removed. Now you can control parallel test runs directly from TestComplete projects.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.59</version>
+    <version>4.65</version>
   </parent>
 
   <properties>
@@ -58,7 +58,7 @@
           <dependency>
               <groupId>io.jenkins.tools.bom</groupId>
               <artifactId>bom-2.361.x</artifactId>
-              <version>2025.v816d28f1e04f</version>
+              <version>2102.v854b_fec19c92</version>
               <scope>import</scope>
               <type>pom</type>
           </dependency>

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcReportAction/index.jelly
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcReportAction/index.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default='false'?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <l:layout title="${%PageTitle}">

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcReportAction/index.jelly
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcReportAction/index.jelly
@@ -29,7 +29,9 @@
             </j:if>
 
             <j:if test="${!it.hasInfo()}">
-                <span style="color:red;">${it.getNoInfoMessage("../../../console")}</span>
+                <span style="color:red;">
+                    <j:out value='${it.getNoInfoMessage("../../../console")}' />
+                </span>
                 <br/><br/>
             </j:if>
 

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcSummaryAction/index.jelly
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcSummaryAction/index.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default='false'?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <l:layout title="${%PageTitle}">
 

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder/config.jelly
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder/config.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default='false'?>
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials" >
 
   <f:block>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
-<?jelly escape-by-default='false'?>
+<?jelly escape-by-default='true'?>
 <div>
   Runs automated tests with TestComplete or TestExecute from Jenkins.
 </div>


### PR DESCRIPTION
SECURITY-2892 / CVE-2023-33002
Severity (CVSS): [High](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H)
Affected plugin: TestComplete
Description:

TestComplete support Plugin 2.8.1 and earlier does not escape the TestComplete project name in its test result page.

This results in a stored cross-site scripting (XSS) vulnerability exploitable by attackers with Item/Configure permission.

[CVE-2023-33002](https://www.tenable.com/cve/CVE-2023-33002) 

https://github.com/advisories/GHSA-5wpg-qcmj-48wh - Can't find link 

[Jenkins Security Advisory 2023-05-16](https://www.jenkins.io/security/advisory/2023-05-16/#SECURITY-2892)

### Solution

The solution is to switch `escape-by-default` in the plugin jelly pages 

This PR updates the plugins and BOM versions as well ...without pumping the supported jenkins version

### Testing done

After applying the fix those steps are performed
* Go to the job configuration page 
* Changed the project name from something like `TestProject` to `TestProject<a>ClickThis</a>`
* Run the job 
* Go to the job result report
* Check that the project name or any other text contain the literal text `TestProject<a>ClickThis</a>` and no other links on Clickme text

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
