### PR TITLE
Remove the support for legacyIds based directory mapping

### DIFF
--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Constants.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Constants.java
@@ -42,7 +42,6 @@ public class Constants {
     public static final String MHT_FILE_EXTENSION = ".mht";
     public static final String ERROR_FILE_EXTENSION = ".txt";
     public static final String ANY_CONSTANT = "any";
-    public static final String LEGACY_IDS_FILE_NAME = "legacyIds";
 
     public static final String SERVICE_ARG = "//LogonAndExecute";
     public static final String SERVICE_ARG_DOMAIN = "//lDomain:";

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcDynamicReportAction.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcDynamicReportAction.java
@@ -34,9 +34,6 @@ import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import static com.smartbear.jenkins.plugins.testcomplete.Constants.LEGACY_IDS_FILE_NAME;
-import static com.smartbear.jenkins.plugins.testcomplete.Constants.REPORTS_DIRECTORY_NAME;
-
 /**
  * @author Igor Filin
  */
@@ -99,7 +96,7 @@ public class TcDynamicReportAction implements Action{
         if (basePathCache != null) {
             basePath = basePathCache;
         } else {
-            basePath = recalculateBasePath(baseReportsPath);
+            basePath = baseReportsPath;
             basePathCache = basePath;
         }
 
@@ -171,43 +168,4 @@ public class TcDynamicReportAction implements Action{
         }
         return targetEntry;
     }
-
-    // https://wiki.jenkins.io/display/JENKINS/JENKINS-24380+Migration
-    private String recalculateBasePath(String basePath) {
-        File path = new File(basePath);
-
-        if (!path.exists()) {
-            path = path.getParentFile();
-
-            String oldDirectoryName = path.getName();
-
-            try {
-                try (BufferedReader br = new BufferedReader(
-                        new InputStreamReader(
-                            new FileInputStream(
-                                new File(path.getParentFile(), LEGACY_IDS_FILE_NAME)
-                                ), "UTF-8"
-                            )
-                        )
-                    ) {
-                    String line;
-                    while ((line = br.readLine()) != null) {
-                        String parts[] = line.split("( )");
-                        if ((parts.length == 2) && (parts[0].equals(oldDirectoryName))) {
-                            File newPath = new File(path.getParentFile(), parts[1] + File.separatorChar + REPORTS_DIRECTORY_NAME);
-                            if (newPath.exists()) {
-                                return newPath.getAbsolutePath();
-                            }
-                            break;
-                        }
-                    }
-                }
-            } catch (IOException e) {
-                // Do nothing
-            }
-        }
-
-        return basePath;
-    }
-
 }


### PR DESCRIPTION
See [JENKINS-75465](https://issues.jenkins.io/browse/JENKINS-75465).

----

<details><summary>Background</summary>

Jenkins previously changed the naming convention for build directories from a date-time-based format to a build number-based format. To facilitate this transition, an automated migrator, `RunIdMigrator`, was introduced to rename existing build folders accordingly. [jenkinsci/jenkins/pull/10456](https://github.com/jenkinsci/jenkins/pull/10456) removes `RunIdMigrator` from Jenkins core, meaning direct upgrades from Jenkins 1.596 (or earlier) to the latest version will no longer be supported. Users must first upgrade to an intermediate version before upgrading to the latest release. </details>

----

**Why is it no longer necessary to check legacyIds mapping in this plugin?**

The method `recalculateBasePath` previously translated a base path like:
`/path/to/jhome/jobs/my-job/builds/2014-12-01_00-01-01/tcreports`
to
`/path/to/jhome/jobs/my-job/builds/10/tcreports`;
where `2014-12-01_00-01-01` mapped to build number `10` using the `legacyIds` file.

However, since Jenkins `1.597` (released on 2015-01-19 - [changelog](https://www.jenkins.io/changelog-old/#v1.597)), new jobs no longer populate the `legacyIds` file, it simply empty. This means for any job created in the last 10+ years, the method has been effectively returning `basePath` unchanged.

Given that virtually all jobs and controllers in use today fall into this category, the legacy lookup is no longer needed, and _this removal simplifies the code while maintaining expected behavior_.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
