### PR TITLE
TC-109088: Made sure we treat no logs as an error, as well as implemented a check if the specified project suite does exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <java.version>11</java.version>
   </properties>
 
-  <artifactId>TestComplete-test</artifactId>
+  <artifactId>TestComplete</artifactId>
   <name>TestComplete support plug-in</name>
   <version>2.10-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,10 @@
 
   <properties>
     <jenkins.version>2.361.4</jenkins.version>
+    <java.version>11</java.version>
   </properties>
 
-  <artifactId>TestComplete</artifactId>
+  <artifactId>TestComplete-test</artifactId>
   <name>TestComplete support plug-in</name>
   <version>2.10-SNAPSHOT</version>
 

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
@@ -628,15 +628,6 @@ public class TcTestBuilder extends Builder implements Serializable, SimpleBuildS
             return;
         }
 
-        //Prefilight check, check if project file exists
-
-        File projectFile = new File(getSuite());
-        if(!projectFile.exists() || projectFile.isDirectory()) {
-            TcLog.error(listener, Messages.TcTestBuilder_UnableToFindProjectFile(), getSuite());
-            run.setResult(Result.FAILURE);
-            return;
-        }
-
         // Search required TC/TE installation
 
         final TcInstallationsScanner scanner = new TcInstallationsScanner(launcher.getChannel(), listener);
@@ -734,6 +725,15 @@ public class TcTestBuilder extends Builder implements Serializable, SimpleBuildS
                 return;
             }
         }
+
+        //Prefilight check, check if project file exists
+        FilePath projectFile = new FilePath(workspace.getSlaveWorkspacePath(), env.expand(getSuite()));
+        if(!projectFile.exists() || projectFile.isDirectory()) {
+            TcLog.error(listener, Messages.TcTestBuilder_UnableToFindProjectFile(), projectFile.getRemote());
+            run.setResult(Result.FAILURE);
+            return;
+        }
+
 
         // TC/TE launching and data processing
         TcReportAction tcReportAction = Optional.ofNullable(filePath)

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
@@ -628,6 +628,15 @@ public class TcTestBuilder extends Builder implements Serializable, SimpleBuildS
             return;
         }
 
+        //Prefilight check, check if project file exists
+
+        File projectFile = new File(getSuite());
+        if(!projectFile.exists() || projectFile.isDirectory()) {
+            TcLog.error(listener, Messages.TcTestBuilder_UnableToFindProjectFile(), getSuite());
+            run.setResult(Result.FAILURE);
+            return;
+        }
+
         // Search required TC/TE installation
 
         final TcInstallationsScanner scanner = new TcInstallationsScanner(launcher.getChannel(), listener);
@@ -684,6 +693,9 @@ public class TcTestBuilder extends Builder implements Serializable, SimpleBuildS
         }
 
         boolean useSessionCreator = chosenInstallation.hasExtendedCommandLine() && (!needToUseService);
+
+        TcLog.info(listener, "Log file: %s", workspace.getMasterLogXFilePath().getName());
+        
 
         // Making the command line
         List<String> passwordsToMask = new ArrayList<>();
@@ -1113,9 +1125,9 @@ public class TcTestBuilder extends Builder implements Serializable, SimpleBuildS
             }
         }
         else {
-            TcLog.warning(listener, Messages.TcTestBuilder_UnableToFindLogFile(),
+            TcLog.error(listener, Messages.TcTestBuilder_UnableToFindLogFile(),
                     workspace.getSlaveLogXFilePath().getName());
-
+            run.setResult(Result.FAILURE);
             testResult.setLogInfo(new TcLogInfo(startTime, 0, 0, 1, 0));
         }
 

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/Messages.properties
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/Messages.properties
@@ -38,6 +38,7 @@ TcTestBuilder.NotWindowsOS = TestComplete/TestExecute can be launched only on th
 TcTestBuilder.InvalidTimeoutValue = Invalid timeout value: "%s". The default timeout will be used.
 TcTestBuilder.InstallationNotFound = Unable to find the specified TestComplete/TestExecute installation.
 
+TcTestBuilder.UnableToFindProjectFile = Unable to find the project file "%s".
 TcTestBuilder.UnableToFindLogFile = Unable to find the log file "%s".
 TcTestBuilder.ErrorMessage = Error: %s.
 TcTestBuilder.RemoteCallingFailed = An error occurred while executing code on the test machine (slave): %s.


### PR DESCRIPTION
### Testing done
Made sure we treat no logs as an error, as well as implemented a check if the specified project suite does exist.

TC-109088