### PR TITLE
TC-110123: Replace JAXB DatatypeConverter with JDK DatatypeFactory

### DIFF
--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Utils.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Utils.java
@@ -33,6 +33,8 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.remoting.RoleChecker;
 
 import javax.crypto.Cipher;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import java.lang.ref.WeakReference;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -178,6 +180,17 @@ public class Utils {
         return (long) ((dSerialDate - 25569) * 24 * 3600 * 1000);
     }
 
+    public static String printDateTime(Calendar cal) {
+        GregorianCalendar gc = new GregorianCalendar();
+        gc.setTimeZone(cal.getTimeZone());
+        gc.setTimeInMillis(cal.getTimeInMillis());
+        try {
+            return DatatypeFactory.newInstance().newXMLGregorianCalendar(gc).toXMLFormat();
+        } catch (DatatypeConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
     static String encryptPassword(String password) throws Exception {
         byte[] keyRawData = Base64.getDecoder().decode(PUBLIC_KEY);
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Utils.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Utils.java
@@ -55,6 +55,16 @@ public class Utils {
 
     private static final int ENC_CHUNK_MAX_SIZE = 116;
 
+    private static final DatatypeFactory XML_DATATYPE_FACTORY = createXmlDatatypeFactory();
+
+    private static DatatypeFactory createXmlDatatypeFactory() {
+        try {
+            return DatatypeFactory.newInstance();
+        } catch (DatatypeConfigurationException e) {
+            throw new IllegalStateException("Failed to obtain a DatatypeFactory instance for XML date/time conversion", e);
+        }
+    }
+
     private Utils() {
     }
 
@@ -184,13 +194,9 @@ public class Utils {
         GregorianCalendar gc = new GregorianCalendar();
         gc.setTimeZone(cal.getTimeZone());
         gc.setTimeInMillis(cal.getTimeInMillis());
-        try {
-            return DatatypeFactory.newInstance().newXMLGregorianCalendar(gc).toXMLFormat();
-        } catch (DatatypeConfigurationException e) {
-            throw new IllegalStateException("Failed to obtain a DatatypeFactory instance for XML date/time conversion", e);
-        }
+        return XML_DATATYPE_FACTORY.newXMLGregorianCalendar(gc).toXMLFormat();
     }
-    
+
     static String encryptPassword(String password) throws Exception {
         byte[] keyRawData = Base64.getDecoder().decode(PUBLIC_KEY);
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Utils.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/Utils.java
@@ -187,7 +187,7 @@ public class Utils {
         try {
             return DatatypeFactory.newInstance().newXMLGregorianCalendar(gc).toXMLFormat();
         } catch (DatatypeConfigurationException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException("Failed to obtain a DatatypeFactory instance for XML date/time conversion", e);
         }
     }
     

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/parser/LogNodeUtils.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/parser/LogNodeUtils.java
@@ -28,7 +28,6 @@ import com.smartbear.jenkins.plugins.testcomplete.Utils;
 import org.w3c.dom.*;
 import org.xml.sax.SAXException;
 
-import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -422,7 +421,7 @@ class LogNodeUtils {
         long startDate = Utils.safeConvertDate(startTime);
         Calendar cal = new GregorianCalendar();
         cal.setTimeInMillis(startDate);
-        return DatatypeConverter.printDateTime(cal);
+        return Utils.printDateTime(cal);
     }
 
 }

--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/parser/LogParser.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/parser/LogParser.java
@@ -32,7 +32,6 @@ import hudson.model.TaskListener;
 import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.*;
 
-import javax.xml.bind.DatatypeConverter;
 import javax.xml.stream.*;
 
 import java.io.IOException;
@@ -283,7 +282,7 @@ public class LogParser implements ILogParser {
         String projectName = LogNodeUtils.getTextProperty(rootOwnerNodeInfoSummary, "test");
         Calendar cal = new GregorianCalendar();
         cal.setTimeInMillis(startDate);
-        String timestamp = DatatypeConverter.printDateTime(cal);
+        String timestamp = Utils.printDateTime(cal);
 
         String rootOwnerNodeFileName = LogNodeUtils.getTextProperty(rootOwnerNode, "filename");
         if (rootOwnerNodeFileName == null || rootOwnerNodeFileName.isEmpty()) {


### PR DESCRIPTION
**Problem**
On Jenkins running Java 11 or newer (Java 17 / 21, Jenkins LTS 2.555+), the plugin fails with: `java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter`

The test run finishes fine (exit code 0). The error happens later, when the plugin reads the TestComplete log and builds the JUnit-style report. Jenkins then marks the build as FAILED.

**Cause**
The plugin used javax.xml.bind.DatatypeConverter.printDateTime() to make the timestamp. JAXB (`javax.xml.bind`) was removed from the JDK in Java 11. Old Jenkins versions still had it by chance; from LTS 2.555 it is no longer on the plugin classpath.

**Fix**
Replaced the JAXB call with `javax.xml.datatype.DatatypeFactory`, which is part of the JDK (JAXP) and is present in Java 8, 11, 17 and 21.

Jira: https://smartbear.atlassian.net/browse/TC-110123

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
